### PR TITLE
Use passed in symbol in slice

### DIFF
--- a/java/src/main/java/com/turleylabs/algo/trader/kata/framework/Slice.java
+++ b/java/src/main/java/com/turleylabs/algo/trader/kata/framework/Slice.java
@@ -63,7 +63,7 @@ public class Slice {
         if (!containsKey(symbol)) {
             return null;
         }
-        return findBar("TQQQ");
+        return findBar(symbol);
     }
 
     public LocalDate getDate() {

--- a/typescript/src/framework/slice.ts
+++ b/typescript/src/framework/slice.ts
@@ -22,7 +22,7 @@ export class Slice {
     if (!this.containsKey(symbol)) {
       return null;
     }
-    return this.findBar('TQQQ');
+    return this.findBar(symbol);
   }
 
   private findCBOE(): CBOE {


### PR DESCRIPTION
This should fix #1 (by making use of the `symbol` argument that is being passed into the function). 